### PR TITLE
chore: replace container platform references with developer platform

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,7 +84,7 @@ brews:
       name: tap
       token: "{{ .Env.GITLAB_TOKEN }}"
     homepage: https://gitlab.intility.com/developer-infrastructure/platform-2.0/minato/idpctl
-    description: "A CLI for managing container platform resources."
+    description: "A CLI for managing developer platform resources."
     goarm: 6
     goamd64: v1
     directory: Formula

--- a/pkg/commands/account/login.go
+++ b/pkg/commands/account/login.go
@@ -25,8 +25,8 @@ func NewLoginCommand(set clientset.ClientSet) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Sign in to Intility Container Platform",
-		Long:  `Sign in to Intility Container Platform using your Intility credentials.`,
+		Short: "Sign in to the Intility Developer Platform",
+		Long:  `Sign in to the Intility Developer Platform using your Intility credentials.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, span := telemetry.StartSpan(cmd.Context(), "account.login")
 			defer span.End()

--- a/pkg/rootcommand/rootcommand.go
+++ b/pkg/rootcommand/rootcommand.go
@@ -21,7 +21,7 @@ func GetRootCommand() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:   build.AppName,
-		Short: build.AppName + " controls your Intility Container Platform instance.",
+		Short: build.AppName + " controls your Intility Developer Platform instance.",
 		Long:  ``,
 		Run:   showHelp,
 	}
@@ -52,8 +52,8 @@ func getVersionCommand() *cobra.Command {
 func getClusterCommand(set clientset.ClientSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
-		Short: "Manage your Intility Container Platform clusters",
-		Long:  `Manage your Intility Container Platform clusters`,
+		Short: "Manage your Intility Developer Platform clusters",
+		Long:  `Manage your Intility Developer Platform clusters`,
 		Run:   showHelp,
 	}
 
@@ -67,8 +67,8 @@ func getClusterCommand(set clientset.ClientSet) *cobra.Command {
 func getAccountCommand(set clientset.ClientSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account",
-		Short: "Manage your Intility Container Platform account",
-		Long:  `Manage your Intility Container Platform account`,
+		Short: "Manage your Intility Developer Platform account",
+		Long:  `Manage your Intility Developer Platform account`,
 		Run:   showHelp,
 	}
 


### PR DESCRIPTION
closes #2 