### PR TITLE
Add suffix to name on cluster creation

### DIFF
--- a/pkg/commands/cluster/create.go
+++ b/pkg/commands/cluster/create.go
@@ -68,8 +68,9 @@ func NewCreateCommand(set clientset.ClientSet) *cobra.Command {
 			// inputs validated, assume correct usage
 			cmd.SilenceUsage = true
 
+			clusterName := options.Name + "-" + generateSuffix()
 			_, err = set.PlatformClient.CreateCluster(ctx, client.NewClusterRequest{
-				Name: options.Name + "-" + generateSuffix(),
+				Name: clusterName,
 				NodePools: []client.NodePool{
 					{
 						Preset:    options.Preset,
@@ -81,7 +82,7 @@ func NewCreateCommand(set clientset.ClientSet) *cobra.Command {
 				return redact.Errorf("could not create cluster: %w", redact.Safe(err))
 			}
 
-			ux.Fsuccess(cmd.OutOrStdout(), "cluster created\n")
+			ux.Fsuccess(cmd.OutOrStdout(), "created cluster: %s\n", clusterName)
 
 			return nil
 		},

--- a/pkg/commands/cluster/create.go
+++ b/pkg/commands/cluster/create.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	maxCount     = 20
+	maxCount     = 8
 	minCount     = 2
 	suffixLength = 6
 )
@@ -27,7 +27,7 @@ var (
 	errCancelledByUser  = redact.Errorf("cancelled by user")
 	errEmptyName        = redact.Errorf("cluster name cannot be empty")
 	errInvalidPreset    = redact.Errorf("invalid node preset: preset must be one of minimal, balanced, performance")
-	errInvalidNodeCount = redact.Errorf("invalid node count: count must be between 2 and 20")
+	errInvalidNodeCount = redact.Errorf("invalid node count: count must be between %d and %d", minCount, maxCount)
 )
 
 type CreateOptions struct {

--- a/pkg/commands/cluster/create.go
+++ b/pkg/commands/cluster/create.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"slices"
 	"strconv"
 
@@ -17,8 +18,9 @@ import (
 )
 
 const (
-	maxCount = 20
-	minCount = 2
+	maxCount     = 20
+	minCount     = 2
+	suffixLength = 6
 )
 
 var (
@@ -67,7 +69,7 @@ func NewCreateCommand(set clientset.ClientSet) *cobra.Command {
 			cmd.SilenceUsage = true
 
 			_, err = set.PlatformClient.CreateCluster(ctx, client.NewClusterRequest{
-				Name: options.Name,
+				Name: options.Name + "-" + generateSuffix(),
 				NodePools: []client.NodePool{
 					{
 						Preset:    options.Preset,
@@ -159,4 +161,15 @@ func validateOptions(options CreateOptions) error {
 	}
 
 	return nil
+}
+
+func generateSuffix() string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	suffix := make([]rune, suffixLength)
+	for i := range suffix {
+		suffix[i] = letters[rand.IntN(len(letters))]
+	}
+
+	return string(suffix)
 }

--- a/pkg/commands/cluster/create_test.go
+++ b/pkg/commands/cluster/create_test.go
@@ -1,0 +1,14 @@
+package cluster
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerateSuffixReturnsValidString(t *testing.T) {
+	suffix := generateSuffix()
+	want := regexp.MustCompile(`[a-z0-9]{6}`)
+	if !want.MatchString(suffix) {
+		t.Errorf("Suffix does not return expected format, expected: [a-z0-9]{6}, got: %s.", suffix)
+	}
+}


### PR DESCRIPTION
* Added [a-z0-9]{6} suffix to cluster name on cluster creation to ensure uniqueness. This ensures the CLI and frontend are consistent and avoids unnecessary cluster name collisions. This is probably a feature we should have added to the backend instead of our client-facing projects, but we can get back to that later.
* Added the newly generated cluster name to the output after a successful cluster creation. This is important information to provide now that we are generating a suffix for them, otherwise they may have a hard time figuring out which cluster they just created.
* Snuck in a fix for the current 20 nodes max limit. It should be 8.