### PR TITLE
chore(release): configure draft releases and force tag creation

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary
- Set `draft: true` so release-please creates releases as drafts
- Set `force-tag-creation: true` to ensure tags are always created

## Test plan
- [ ] Verify next release-please run creates a draft release
- [ ] Verify tags are created even when no release notes are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)