### PR TITLE
ci: trigger release workflow on tag push instead of release published

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,8 +4,9 @@
 name: Build, test, release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Change workflow trigger from `release: types: [published]` to `push: tags: v*`
- Fixes goreleaser failing with `422 Cannot upload assets to an immutable release` — release-please now creates draft releases, which never triggered the `published` event
- Goreleaser derives the version from the git tag automatically, so no other changes needed

## Test plan
- [ ] Merge next release-please PR and verify the tag push triggers the workflow
- [ ] Verify goreleaser successfully uploads assets to the draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)