### PR TITLE
ci(release): use existing draft release for goreleaser uploads

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,7 @@ release:
   github:
     owner: intility
     name: indev
+  use_existing_draft: true
 
 archives:
   - formats: [ 'tar.gz' ]


### PR DESCRIPTION
## Summary
- Add `use_existing_draft: true` to `.goreleaser.yaml` so goreleaser uploads assets to the draft release created by release-please instead of creating a separate published release

## Test plan
- [ ] Verify next release has assets uploaded to the release-please draft instead of a new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)